### PR TITLE
CodeFix: RankingApp/ClientApp/src/components/Item.js

### DIFF
--- a/RankingApp/ClientApp/src/components/Item.js
+++ b/RankingApp/ClientApp/src/components/Item.js
@@ -1,4 +1,6 @@
-﻿const Item = ({item, drag, itemImgObj }) => {
+﻿import PropTypes from 'prop-types';
+
+const Item = ({ item, drag, itemImgObj }) => {
     return (
         <div className="unranked-cell">
             <img id={`item-${item.id}`} src={itemImgObj.image}
@@ -7,4 +9,11 @@
         </div>     
     )
 }
+
+Item.propTypes = {
+    item: PropTypes.object.isRequired,
+    drag: PropTypes.func.isRequired,
+    itemImgObj: PropTypes.object.isRequired
+};
+
 export default Item;


### PR DESCRIPTION
- Line: 1 Criterion: 3. Prop Types Comment: Prop types for "item", "drag", and "itemImgObj" are not defined. Defining prop types is important for documenting component expectations and catching bugs.