### PR TITLE
**Summary of the code fixes made**

### DIFF
--- a/RankingApp/ClientApp/src/components/Item.js
+++ b/RankingApp/ClientApp/src/components/Item.js
@@ -1,10 +1,32 @@
-﻿const Item = ({item, drag, itemImgObj }) => {
-    return (
-        <div className="unranked-cell">
-            <img id={`item-${item.id}`} src={itemImgObj.image}
-                style={{ cursor: "pointer" }} draggable="true" onDragStart={drag}
-            />
-        </div>     
-    )
+```jsx
+﻿import PropTypes from 'prop-types';
+
+const Item = ({ item, drag, itemImgObj }) => {
+    if (item && itemImgObj.image) {
+        return (
+            <div className="unranked-cell">
+                <button 
+                  id={`item-${item.id}`} 
+                  style={{cursor: "pointer", background: "none", border: "none"}} 
+                  draggable="true" 
+                  onDragStart={drag}
+                >
+                <img src={itemImgObj.image} alt={`item ${item.id}`} />
+                </button>
+            </div>     
+        );
+    }
+    return null;
 }
+
+Item.propTypes = {
+    item: PropTypes.shape({
+        id: PropTypes.number.isRequired
+    }).isRequired,
+    itemImgObj: PropTypes.shape({
+        image: PropTypes.string.isRequired
+    }).isRequired,
+    drag: PropTypes.func.isRequired
+};
+
 export default Item;


### PR DESCRIPTION
- Converted the `img` element that has a drag event to a `button` element since interactive elements should have event listeners, not non-interactive elements like `img`. This addresses the issue of assigning mouse or keyboard event listeners to a non-interactive element.
- Set `alt` property on the `img` tag to provide assistive text for the image which is required for accessibility. In this case, it provides context for the item using its id.
- Added PropTypes validation for `item`, `drag`, and `itemImgObj` to validate the props passed to the component. This included specifying the shape of `item` and `itemImgObj` and ensuring that `item.id` and `itemImgObj.image` are present and have the correct types.
- Used a short-circuit evaluation to return `null` if `item` or the `itemImgObj.image` is not provided, adding a guard to prevent possible runtime errors.

**Additional potential considerations**

- If the image is purely decorative and does not add any informative content, the `alt` attribute could be an empty string. However, if the image represents a specific item that carries meaning for the user, keep the `alt` attribute meaningful as done in the code fix.
- The `draggable` attribute could be omitted if all elements are meant to be draggable by default in the parent container or context.
- If there is additional hidden content associated with the items that is not conveyed by just the image and its `alt` tag, consider adding `aria` attributes to enhance the accessibility of the component.
- The styles for the button have been set inline to maintain the previous appearance, but for maintainability, consider using external style sheets or CSS-in-JS libraries for better organization of styles.
- Ensure proper error handling or default values if `item` or `itemImgObj` could be undefined or null in certain scenarios within the application's logic.