### PR TITLE
**Summary of the code fixes made**

### DIFF
--- a/RankingApp/ClientApp/src/components/Item.js
+++ b/RankingApp/ClientApp/src/components/Item.js
@@ -1,10 +1,28 @@
-const Item = ({item, drag, itemImgObj }) => {
+import PropTypes from 'prop-types';
+
+const Item = ({ item, drag, itemImgObj }) => {
     return (
         <div className="unranked-cell">
-            <img id={`item-${item.id}`} src={itemImgObj.image}
-                style={{ cursor: "pointer" }} draggable="true" onDragStart={drag}
+            <img 
+                id={`item-${item.id}`}
+                src={itemImgObj.image}
+                alt={`item-${item.id}`} // meaningful alt text based on the item id
+                style={{ cursor: "pointer" }}
+                draggable="true"
+                onDragStart={drag}
             />
         </div>     
-    )
-}
+    );
+};
+
+Item.propTypes = {
+    item: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+    }).isRequired,
+    drag: PropTypes.func.isRequired,
+    itemImgObj: PropTypes.shape({
+        image: PropTypes.string.isRequired,
+    }).isRequired,
+};
+
 export default Item;


### PR DESCRIPTION
- Added `alt` attribute to the `img` tag with a descriptive text based on the item's id. This improves accessibility by providing meaningful information for screen readers and adheres to semantic HTML best practices.
- Defined PropTypes for `Item` component to validate `item`, `drag`, and `itemImgObj` props. This ensures the expected types and structure for the utilized props are documented and enforced, preventing potential bugs or unexpected behavior.
- Included a specific PropType validation for `item.id` and `itemImgObj.image` since these specific properties are being accessed within the component, adhering to the SonarQube rule of props validation.
- All PropTypes are marked as `.isRequired` to highlight the necessity of these props in the component's functionality.

**Additional potential considerations**
- Refactoring inline styles (e.g., `style={{ cursor: "pointer" }}`) to a separate CSS class if there are complex styles or reusability is needed for the defined styles.
- Ensure that the provided `alt` text for images aligns with the content and purpose of the image. If the image is purely decorative, an empty string should be used for the `alt` attribute.
- If the `drag` function relies on specific properties of the `item` or `itemImgObj`, consider additional prop validation to define those dependencies.
- The `draggable` attribute is set to `"true"`. However, if there's a need to conditionally enable or disable the drag feature, it may be worth passing a prop to control this behavior.